### PR TITLE
fix: drop universal wheel naming

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,9 +30,6 @@ replace = version = "{new_version}"
 [bumpversion:file:docs/conf.py]
 
 
-[bdist_wheel]
-universal = 1
-
 [flake8]
 exclude = docs
 


### PR DESCRIPTION
This is adding a Python 2 tag and a py2.py3 wheel name; there's no need to include this if you don't support Python 2 anymore. Just passing by and noticed this. :)